### PR TITLE
fixed edit button to edit found and lost report

### DIFF
--- a/app/views/homepages/index.html.erb
+++ b/app/views/homepages/index.html.erb
@@ -11,7 +11,7 @@
             <p class="card-text"><strong>Title:</strong> <%= @latest_found_item.title %></p>
             <p class="card-text"><strong>Description:</strong> <%= @latest_found_item.description %></p>
             <p class="card-text"><strong>Location:</strong> <%= @latest_found_item.location %></p>
-            <%= link_to "View", found_item_path(@latest_found_item), class: "btn btn-primary" %>
+            <%= link_to "Edit", edit_found_item_path(@latest_found_item), class: "btn btn-primary" %>
           </div>
         </div>
       <% end %>
@@ -23,7 +23,7 @@
             <p class="card-text"><strong>Title:</strong> <%= @latest_lost_item.title %></p>
             <p class="card-text"><strong>Description:</strong> <%= @latest_lost_item.description %></p>
             <p class="card-text"><strong>Location:</strong> <%= @latest_lost_item.location %></p>
-            <%= link_to "View", lost_item_path(@latest_lost_item), class: "btn btn-primary" %>
+            <%= link_to "Edit", edit_lost_item_path(@latest_lost_item), class: "btn btn-primary" %>
           </div>
         </div>
       <% end %>
@@ -38,7 +38,7 @@
             <p class="card-text"><strong>Title:</strong><%= item.title %></p>
             <p class="card-text"><strong>Description:</strong><%= item.description %></p>
             <p class="card-text"><strong>Location:</strong> <%= item.location %></p>
-            <%= link_to "View", found_item_path(item), class: "btn btn-primary" %>
+            <%= link_to "Edit", edit_found_item_path(item), class: "btn btn-primary" %>
           </div>
         </div>
       <% end %>
@@ -49,7 +49,7 @@
             <p class="card-text"><strong>Title:</strong><%= item.title %></p>
             <p class="card-text"><strong>Description:</strong><%= item.description %></p>
             <p class="card-text"><strong>Location:</strong> <%= item.location %></p>
-            <%= link_to "View", lost_item_path(item), class: "btn btn-primary" %>
+            <%= link_to "Edit", edit_lost_item_path(item), class: "btn btn-primary" %>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
User can edit their found or lost reports before a match
<img width="1440" height="788" alt="Screenshot 2025-07-18 at 21 37 53" src="https://github.com/user-attachments/assets/9a4ff126-0b87-4a83-b415-24274fcae406" />

Links successfully to edit found report
<img width="1440" height="713" alt="Screenshot 2025-07-18 at 21 38 01" src="https://github.com/user-attachments/assets/d50d3595-fc84-493e-885c-038be3b9b2e7" />

Links successfully to edit lost report
<img width="1439" height="787" alt="Screenshot 2025-07-18 at 21 38 33" src="https://github.com/user-attachments/assets/a3946724-ec51-4e54-9bc2-529b7224e10c" />
