### PR TITLE
Fix login error message rendering and styling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -57,3 +57,13 @@
 .edit-icon:hover {
   color: #000;
 }
+
+.alert-danger {
+  color: #721c24;
+  background-color: #f8d7da;
+  border: 1px solid #f5c6cb;
+  padding: 0.75rem 1.25rem;
+  border-radius: 0.25rem;
+  margin-bottom: 1rem;
+  text-align: center;
+}

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,11 @@
 <h2>Log in</h2>
 
+<% if flash[:alert] %>
+  <div class="alert alert-danger">
+    <%= flash[:alert] %>
+  </div>
+<% end %>
+
 <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="form-inputs">
     <%= f.input :email,


### PR DESCRIPTION
- Added flash alert rendering (`flash[:alert]`) to `app/views/devise/sessions/new.html.erb`
- Styled message for visual consistency 
- Confirmed proper display on invalid login attempts

<img width="1440" height="857" alt="Screenshot 2025-07-22 at 20 37 16" src="https://github.com/user-attachments/assets/6ee82125-916e-434a-ab02-0c615a1fb1e0" />


