### PR TITLE
Fix: Register flash controller to enable auto-dismiss after 4 seconds

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,12 +1,12 @@
-// Import and register all your controllers from the importmap via controllers/**/*_controller
 import { Application } from "@hotwired/stimulus"
 import { eagerLoadControllersFrom } from "@hotwired/stimulus-loading"
 import AddressAutocompleteController from "./address_autocomplete_controller.js"
+import FlashController from "./flash_controller.js"
 
 const application = Application.start()
 
 // Eager-load other controllers in the folder
 eagerLoadControllersFrom("controllers", application)
 
-// Manually register the address autocomplete controller
 application.register("address-autocomplete", AddressAutocompleteController)
+application.register("flash", FlashController)


### PR DESCRIPTION
All flash notifications in the bottom right corner now disappear after 4 seconds

This also applies to the other ticket relating to forms "Bug: Fixing form notices, it should disappear automatically"
