### PR TITLE
Add thank-you notification when match is confirmed with another user'…

### DIFF
--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -3,4 +3,18 @@ class Match < ApplicationRecord
   belongs_to :found_item
 
   attribute :confirmed, :boolean, default: false
+
+  after_update :send_thank_you_if_confirmed
+
+  private
+
+  def send_thank_you_if_confirmed
+    return unless saved_change_to_confirmed? && confirmed?
+    return if lost_item.user_id == found_item.user_id
+
+    Notification.create!(
+      user: found_item.user,
+      message: "Someone recovered their lost item thanks to your report."
+    )
+  end
 end


### PR DESCRIPTION
This PR implements a feature that sends a thank-you notification to users who reported a found item that helped someone recover their lost item.

Tested:

Manually tested in Rails console:

Created users, lost and found items

Created and confirmed a match

Confirmed the correct user received a thank-you notification

