### PR TITLE
Style: update lost items progress stepper

### DIFF
--- a/app/assets/stylesheets/components/_matches_show.scss
+++ b/app/assets/stylesheets/components/_matches_show.scss
@@ -144,29 +144,63 @@ h3 {
 }
 
 .match-steps-wrapper {
-    max-width: 500px;
-    margin: 0 auto;
-    margin-bottom: 5rem;
-    margin-top: 4rem;
+  max-width: 600px;
+  margin: 4rem auto 5rem auto;
+  position: relative;
 }
 
 .match-steps {
-    width: 100%;
-}
+  display: flex;
+  justify-content: space-between;
+  position: relative;
 
-.connector {
-    flex: 1;
-    height: 2px;
-}
-
-.step {
-    display: inline-flex;
+  .step-horizontal {
+    display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-content: center;
+    position: relative;
+    flex: 1;
+
+    // Black connector line before steps 2 and 3
+    &.middle::before,
+    &.last::before {
+      content: '';
+      position: absolute;
+      top: 16px;
+      left: -50%;
+      width: 100%;
+      height: 2px;
+      background-color: black; // changed from #98B39A
+      z-index: 0;
+    }
+  }
+
+  .step-circle {
     width: 32px;
     height: 32px;
     border-radius: 50%;
-    background: #e0e0e0;
-    font-size: 1rem;
+    background: white;
+    color: black; // text color
+    border: 2px solid black; // border color
     font-weight: bold;
+    font-size: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1;
+    position: relative;
+  }
+
+  .step-horizontal.active .step-circle {
+    background-color: black; // filled circle
+    color: white; // text inside active circle
+  }
+
+  .step-label {
+    margin-top: 0.4rem;
+    font-size: 0.95rem;
+    font-weight: bold;
+    color: black; // label text
+    text-align: center;
+  }
 }

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -1,33 +1,23 @@
 <% step = @step %>
+
 <div class="match-steps-wrapper">
-  <div class="match-steps d-flex align-items-center justify-content-between">
-    <div class="text-center">
-      <span class="step <%= 'active' if step == 1 %>">1</span>
-      <% if step == 1 %>
-        <div class="step-label">Check your match</div>
-      <% end %>
+  <div class="match-steps">
+    <div class="step-horizontal first <%= 'active' if step == 1 %>">
+      <div class="step-circle">1</div>
+      <div class="step-label">Check your match</div>
     </div>
 
-    <span class="connector"></span>
-
-    <div class="text-center">
-      <span class="step <%= 'active' if step == 2 %>">2</span>
-      <% if step == 2 %>
-        <div class="step-label">Retrieve your item</div>
-      <% end %>
+    <div class="step-horizontal middle <%= 'active' if step == 2 %>">
+      <div class="step-circle">2</div>
+      <div class="step-label">Retrieve your item</div>
     </div>
 
-    <span class="connector"></span>
-
-    <div class="text-center">
-      <span class="step <%= 'active' if step == 3 %>">3</span>
-      <% if step == 3 %>
-        <div class="step-label">Confirm match</div>
-      <% end %>
+    <div class="step-horizontal last <%= 'active' if step == 3 %>">
+      <div class="step-circle">3</div>
+      <div class="step-label">Confirm match</div>
     </div>
   </div>
 </div>
-
 
 <div class="match-card d-flex">
   <% if @match.found_item.images.attached? %>
@@ -48,25 +38,20 @@
   <div class="match-content">
     <div class="match-text mb-4">
       <h3><strong>📌 It's a match !</strong></h3>
+
       <% if step == 1 %>
         <p><%= @match.found_item.title %></p>
-      <% end %>
-
-      <% if step == 2 %>
+        <p><strong>Is this item yours ?</strong></p>
+      <% elsif step == 2 %>
         <p><%= @match.found_item.title %></p>
         <p><strong>Description:</strong> <%= @match.found_item.description %></p>
         <p><strong>Location:</strong> <%= @match.found_item.location %></p>
-        <!-- MAP area -->
         <div id="map" style="height: 200px; width: 500px; background: #a1c0e3;">MAP PLACEHOLDER</div>
-      <% end %>
-
-      <% if step == 1 %>
-        <p><strong>Is this item yours ?</strong></p>
       <% elsif step == 3 %>
         <p><%= @match.found_item.title %></p>
         <%= form_with url: lost_item_match_path(@lost_item, @match), method: :patch do |f| %>
           <div class="mb-3" style="width: 450px; font-weight: bold;">
-            <%= f.label :review,"Leave a kind message to the finder:", class: "mb-2" %>
+            <%= f.label :review, "Leave a kind message to the finder:", class: "mb-2" %>
             <%= f.text_area :review, rows: 3, class: "form-control", style: "border-radius: 8px" %>
           </div>
         <% end %>
@@ -110,9 +95,7 @@
         <%= button_to "FoundIt!",
               lost_item_match_path(@lost_item, @match),
               method: :patch,
-
               params: { match: { confirmed: true, step: 3, finalize: true } },
-
               class: "btn btn-success",
               style: "border-radius: 30px; width: 8rem; font-weight: bold; color: white; border-color: #f5b220; margin-left: 16rem; background-color: #f5b220;" %>
       <% end %>


### PR DESCRIPTION
Description: 
- Centered connecting line between steps
- Clean circle and label styling
- Converted all indicators to black for stronger contrast
<img width="1920" height="959" alt="Screenshot 2025-07-29 at 16 39 41" src="https://github.com/user-attachments/assets/dd2ab765-4279-488e-aee0-6f29a557b6d2" />
1.
<img width="1920" height="955" alt="Screenshot 2025-07-29 at 16 39 56" src="https://github.com/user-attachments/assets/958452df-1f9e-47be-a00d-f608068a5b7a" />
2.
<img width="1920" height="953" alt="Screenshot 2025-07-29 at 16 40 23" src="https://github.com/user-attachments/assets/5568e027-1195-4bd0-85f6-f556763a68e9" />
3.