### PR TITLE
synchronized delete process for lost report with matches and notifica…

### DIFF
--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -3,6 +3,11 @@ class Match < ApplicationRecord
   belongs_to :found_item
   attribute :confirmed, :boolean, default: false
   after_update :send_thank_you_if_confirmed
+  after_destroy :destroy_notifications
+
+  def destroy_notifications
+    Notification.where(notifiable: self).destroy_all
+  end
 
   validate :users_cannot_be_same
   def users_cannot_be_same

--- a/app/views/lost_items/_form.html.erb
+++ b/app/views/lost_items/_form.html.erb
@@ -34,9 +34,8 @@
         <%= f.input :date_lost, as: :date %>
         <div class="d-flex gap-2 mt-3">
           <% if lost_item.persisted? %>
-            <%= button_to "Delete Lost Item", lost_item_path(lost_item),
-            method: :delete,
-            data: { confirm: "Are you sure you want to delete this lost item report?" },
+            <%= link_to "Delete Lost Item", lost_item_path(lost_item),
+            data: { confirm: "Are you sure you want to delete this lost item report?", turbo_method: :delete },
             class: "custom-outline-btn mt-3" %>
           <% end %>
           <%= f.button :submit, lost_item.persisted? ? "Update Lost Item" : "Report Lost Item", class: "custom-action-btn mt-3" %>


### PR DESCRIPTION
Now, when a lost report, which has matches and a notification, is deleted, its matches and notifications will be deleted together. This prevents us from having orphaned mathes and notifications.