### PR TITLE
Add conditional View match button on homepage lost item report that only shows up with a possible match

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,7 @@
 @import "components/button";
 @import "components/index";
 @import "components/form";
+@import "components/index";
 
 .alert-danger {
   color: #721c24;

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -91,3 +91,20 @@
 .card-body {
   position: relative;
 }
+
+.custom-view-match-outline-btn {
+  background-color: transparent;
+  border: 2px solid #f98e4b;
+  color: #f98e4b;
+  font-weight: 600;
+  border-radius: 50px;
+  padding: 0.5rem 1.5rem;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.3s ease, color 0.3s ease;
+
+  &:hover {
+    background-color: #f98e4b;
+    color: white;
+  }
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -1,6 +1,7 @@
 // Import your components CSS files here.
 @import "alert";
 @import "avatar";
+@import "button";
 @import "form_legend_clear";
 @import "navbar";
 @import "stepper";

--- a/app/controllers/homepages_controller.rb
+++ b/app/controllers/homepages_controller.rb
@@ -31,7 +31,6 @@ class HomepagesController < ApplicationController
         @latest_lost_item_matched = @latest_lost_item_match.present?
       end
 
-
       @rest_found_items = @latest_found_item.present? ? @found_items.where.not(id: @latest_found_item.id) : @found_items
       @rest_lost_items  = @latest_lost_item.present?  ? @lost_items.where.not(id: @latest_lost_item.id) : @lost_items
     end

--- a/app/views/homepages/index.html.erb
+++ b/app/views/homepages/index.html.erb
@@ -61,6 +61,16 @@
             <div class="right-section text-start">
               <p class="card-text"><strong>Location:</strong> <%= @latest_lost_item.location %></p>
               <p class="card-text"><strong>Status:</strong> <%= item_status(@latest_lost_item, current_user) %></p>
+
+              <% if @latest_lost_item_match.present? && !@latest_lost_item_match.confirmed? %>
+                <% match = @latest_lost_item_match %>
+                <%= button_to "View match",
+                    lost_item_match_path(@latest_lost_item, match, step: 1),
+                    method: :get,
+                    class: "custom-view-match-outline-btn mt-2",
+                    form: { data: { turbo: false } } %>
+              <% end %>
+
               <%= link_to edit_lost_item_path(@latest_lost_item), class: "icon-link", title: "Edit" do %>
                 <img src="<%= asset_path('Edit.svg') %>" width="16" height="16" alt="Edit" class="edit-icon">
               <% end %>
@@ -132,7 +142,7 @@
           <div class="step" data-step="2"></div>
           <div class="step-text">
             <div class="step-title">Connect with the right person</div>
-            <div class="step-description">We'll match and notify you with potential owners or finders.</div>
+            <div class="step-description">We’ll match and notify you with potential owners or finders.</div>
           </div>
         </div>
 


### PR DESCRIPTION
Updated the homepage to display a "View match" button only when there is a possible match on a lost item that is not yet confirmed.

The button disappears once the match is confirmed, keeping the UI clean.

Added necessary controller and view logic to support this feature.

Styled the button with the outlined style to match design guidelines.

Please review and let me know if any changes are needed!

<img width="1917" height="1043" alt="Screenshot 2025-08-07 at 18 11 21" src="https://github.com/user-attachments/assets/5a71a369-927a-4dd5-b4d0-3fd0533893ee" />
<img width="1920" height="1038" alt="Screenshot 2025-08-07 at 18 12 35" src="https://github.com/user-attachments/assets/1f47b4d5-435c-4ce9-a82e-4ced556de43b" />
