### PR TITLE
Fix: show thank-you notes on profiles & allow finder access to thank you notes via notification

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -12,10 +12,15 @@ class NotificationsController < ApplicationController
     @unread_notifications_count = current_user.notifications.where(read: false).count
 
     respond_to do |format|
-      format.html { redirect_back fallback_location: notifications_path }
+      if params[:redirect_to] == "profile"
+        format.html { redirect_to profiles_path }
+      else
+        format.html { redirect_back fallback_location: notifications_path }
+      end
       format.js
     end
   end
+
 
   def mark_all_as_read
     current_user.notifications.where(read: false).update_all(read: true)

--- a/app/controllers/thank_you_notes_controller.rb
+++ b/app/controllers/thank_you_notes_controller.rb
@@ -6,6 +6,14 @@ class ThankYouNotesController < ApplicationController
     @thank_you_notes = ThankYouNote.where(recipient: @user)
   end
 
+  def show
+    @thank_you_note = ThankYouNote.find(params[:id])
+
+    unless @thank_you_note.recipient == current_user
+      redirect_to root_path, alert: "You are not authorized to view this thank-you note."
+    end
+  end
+
   def new
     @thank_you_note = ThankYouNote.new
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,6 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <!-- in app/views/layouts/application.html.erb -->
     <%= javascript_importmap_tags %>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" defer></script>
@@ -24,7 +23,7 @@
 
           <% if user_signed_in? %>
             <div class="d-flex align-items-center ms-auto">
-              <!-- Cloche + dropdown -->
+              <!-- Notification Bell -->
               <div class="dropdown position-relative d-inline-block w-auto" style="padding-right: 0rem;">
                 <button id="notification-bell"
                         type="button"
@@ -53,57 +52,60 @@
                       </div>
                     <% end %>
                     <ul class="list-unstyled mb-0">
-                    <% @notifications.each do |notification| %>
-                      <% if notification.notifiable.present? %>
-                        <li class="mb-2 p-2 <%= 'fw-bold' unless notification.read %> position-relative">
-                          <% if notification.notifiable_type == "Match" && notification.notifiable.respond_to?(:lost_item) && notification.notifiable.lost_item.present? %>
-                            <%= link_to lost_item_match_path(notification.notifiable.lost_item, notification.notifiable, step: 1),
-                                        class: "text-decoration-none text-dark d-block w-100 h-100" do %>
-                              <%= notification.content %>
-                              <%= notification.message %>
-                            <% end %>
-                          <% elsif notification.notifiable_type == "LostItem" %>
-                            <%= link_to lost_item_path(notification.notifiable),
-                                class: "text-decoration-none text-dark d-block" do %>
-                              <div><%= notification.content %></div>
-                              <div><%= notification.message %></div>
-                            <% end %>
-                          <% else %>
+                      <% @notifications.each do |notification| %>
+                        <% if notification.notifiable.present? %>
+                          <li class="mb-2 p-2 <%= 'fw-bold' unless notification.read %> position-relative">
+                            <% if notification.notifiable_type == "Match" && notification.notifiable.respond_to?(:lost_item) && notification.notifiable.lost_item.present? %>
+                              <%= link_to lost_item_match_path(notification.notifiable.lost_item, notification.notifiable, step: 1),
+                                          class: "text-decoration-none text-dark d-block w-100 h-100" do %>
+                                <%= notification.content %>
+                                <%= notification.message %>
+                              <% end %>
+                            <% elsif notification.notifiable_type == "LostItem" %>
                               <%= link_to lost_item_path(notification.notifiable),
-                                class: "text-decoration-none text-dark d-block" do %>
-                              <div><%= notification.content %></div>
-                              <div><%= notification.message %></div>
-                            <% end %>
-
-                          <% end %>
-
-                          <% unless notification.read %>
-                            <div class="d-flex justify-content-between small text-muted">
-                              <%= link_to "Mark as read",
-                                          mark_as_read_notification_path(notification),
+                                          class: "text-decoration-none text-dark d-block" do %>
+                                <div><%= notification.content %></div>
+                                <div><%= notification.message %></div>
+                              <% end %>
+                            <% elsif notification.notifiable_type == "ThankYouNote" %>
+                              <%= link_to mark_as_read_notification_path(notification, redirect_to: "profile"),
                                           method: :patch,
-                                          remote: true,
-                                          onclick: "event.stopPropagation();" %>
-                            </div>
-                          <% end %>
-                        </li>
-                      <% else %>
-                        <li class="mb-2 p-2 <%= 'fw-bold' unless notification.read %>">
-                            <%= link_to lost_item_path(notification.notifiable),
-                                class: "text-decoration-none text-dark d-block" do %>
-                              <div><%= notification.content %></div>
-                              <div><%= notification.message %></div>
+                                          class: "text-decoration-none text-dark d-block w-100 h-100" do %>
+                                <div><%= notification.content %></div>
+                                <div><%= notification.message %></div>
+                              <% end %>
+                            <% else %>
+                              <%= link_to lost_item_path(notification.notifiable),
+                                          class: "text-decoration-none text-dark d-block" do %>
+                                <div><%= notification.content %></div>
+                                <div><%= notification.message %></div>
+                              <% end %>
                             <% end %>
-                        </li>
-                      <% end %>
 
-                    <% end %>
-                  </ul>
+                            <% unless notification.read %>
+                              <div class="d-flex justify-content-between small text-muted">
+                                <%= link_to "Mark as read",
+                                            mark_as_read_notification_path(notification),
+                                            method: :patch,
+                                            remote: true,
+                                            onclick: "event.stopPropagation();" %>
+                              </div>
+                            <% end %>
+                          </li>
+                        <% else %>
+                          <!-- Fallback when notifiable is missing -->
+                          <li class="mb-2 p-2 <%= 'fw-bold' unless notification.read %>">
+                            <div><%= notification.content %></div>
+                            <div><%= notification.message %></div>
+                          </li>
+                        <% end %>
+                      <% end %>
+                    </ul>
                 </div>
 
-                  <%= link_to profiles_path, class: "text-dark me-3", title: "Your Profile", style: "margin-left: 1rem;" do %>
-                    <i class="fa-regular fa-user" style="font-size: 1.4rem; margin-top: 1.1rem; padding-left: 0.2rem;"></i>
-                  <% end %>
+                <%= link_to profiles_path, class: "text-dark me-3", title: "Your Profile", style: "margin-left: 1rem;" do %>
+                  <i class="fa-regular fa-user" style="font-size: 1.4rem; margin-top: 1.1rem; padding-left: 0.2rem;"></i>
+                <% end %>
 
               </div>
             </div>
@@ -113,14 +115,13 @@
           <% end %>
         </div>
       </nav>
+
       <% flash.each do |key, message| %>
-        <div
-          class="alert alert-<%= key == 'notice' ? 'success' : 'danger' %>"
-          data-controller="flash"
-          data-flash-timeout-value="4000"
-        >
+        <div class="alert alert-<%= key == 'notice' ? 'success' : 'danger' %>"
+             data-controller="flash"
+             data-flash-timeout-value="4000">
           <%= message %>
-      </div>
+        </div>
       <% end %>
 
       <%= yield %>
@@ -171,6 +172,5 @@
         bell.dataset.listenerAttached = "true";
       });
     </script>
-
   </body>
 </html>

--- a/app/views/lost_items/index.html.erb
+++ b/app/views/lost_items/index.html.erb
@@ -1,27 +1,32 @@
 <h1>All Lost Items</h1>
 
+<%= link_to 'Report New Lost Item', new_lost_item_path, class: 'btn btn-primary mb-3' %>
 
-<%= link_to 'Report New Lost Item', new_lost_item_path %>
-
-<ul>
+<% if @lost_items.any? %>
   <% @lost_items.each do |item| %>
-    <li>
-      <strong><%= link_to item.title, lost_item_path(item) %></strong><br>
-      <em><%= item.category %></em> | <%= item.location %> | <%= item.date_lost %>
-    </li>
+    <div class="card my-3 p-3 bg-light">
+      <h5 class="mb-2">
+        <%= link_to item.title, lost_item_path(item), class: 'text-decoration-none' %>
+      </h5>
+
+      <p class="mb-1"><strong>Category:</strong> <%= item.category %></p>
+      <p class="mb-1"><strong>Location:</strong> <%= item.location %></p>
+      <p class="mb-1"><strong>Date lost:</strong> <%= item.date_lost %></p>
+
+      <% if item.description.present? %>
+        <p class="mb-3"><strong>Description:</strong> <%= item.description %></p>
+      <% end %>
+
+      <div class="d-flex gap-2">
+        <%= link_to 'Show',  lost_item_path(item), class: 'btn btn-sm btn-outline-primary' %>
+        <%= link_to 'Edit',  edit_lost_item_path(item), class: 'btn btn-sm btn-outline-secondary' %>
+        <%= link_to 'Delete', lost_item_path(item),
+              method: :delete,
+              data: { confirm: "Are you sure?" },
+              class: 'btn btn-sm btn-danger' %>
+      </div>
+    </div>
   <% end %>
-</ul>
-=======
-<%= link_to 'Report New Lost Item', new_lost_item_path, class: 'btn btn-primary' %>
-
-<% @lost_items.each do |item| %>
-  <div class="card my-3 p-3 bg-light">
-    <h5><%= item.title %></h5>
-    <p><strong>Description:</strong> <%= item.description %></p>
-    <p><strong>Location:</strong> <%= item.location %></p>
-
-    <%= link_to 'Show', lost_item_path(item), class: 'btn btn-sm btn-outline-primary' %>
-    <%= link_to 'Edit', edit_lost_item_path(item), class: 'btn btn-sm btn-outline-secondary' %>
-    <%= link_to 'Delete', lost_item_path(item), method: :delete, data: { confirm: "Are you sure?" }, class: 'btn btn-sm btn-danger' %>
-  </div>
+<% else %>
+  <p class="text-muted">No lost items yet.</p>
 <% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -3,7 +3,9 @@
 <ul>
   <% @notifications.each do |notification| %>
     <li style="<%= 'font-weight: bold;' unless notification.read %>">
-      <%= notification.message %>
+      <%= link_to notification.message,
+            mark_as_read_notification_path(notification, redirect_to: "profile"),
+            method: :patch %>
       <% unless notification.read %>
         <%= link_to "Mark as read", mark_as_read_notification_path(notification), method: :patch %>
       <% end %>

--- a/app/views/thank_you_notes/show.html.erb
+++ b/app/views/thank_you_notes/show.html.erb
@@ -1,0 +1,5 @@
+<div class="card p-4 mt-5">
+  <h3>Thank-You Note</h3>
+  <p><%= @thank_you_note.message %></p>
+  <p class="text-muted"><%= @thank_you_note.created_at.strftime("%B %d, %Y") %></p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,8 +38,9 @@ Rails.application.routes.draw do
 
   resource :profiles, only: [:show, :edit, :update]
 
+  # ✅ Updated here
   resources :users, only: [:show, :edit, :update] do
-    resources :thank_you_notes, only: [:index, :new, :create]
+    resources :thank_you_notes, only: [:index, :new, :create, :show]
   end
 
   root "homepages#index"
@@ -50,5 +51,4 @@ Rails.application.routes.draw do
 
   # We updates profile to profiles so we can use avatar with cloudinary
   # resource :profile, only: [:show]
-
 end


### PR DESCRIPTION
Added thank-you notes to profiles.

Updated notifications to allow finder access.

Maintained coding best practices & merged with latest master.

Tested with thank-you notes notification


Clicking the thank you notes notification now takes you to your profile where you can read them